### PR TITLE
Fixed iOS 10 crash

### DIFF
--- a/CoreDataMigration-Example/Extensions/NSManagedObjectModel/NSManagedObjectModel+Resource.swift
+++ b/CoreDataMigration-Example/Extensions/NSManagedObjectModel/NSManagedObjectModel+Resource.swift
@@ -16,7 +16,11 @@ extension NSManagedObjectModel {
     static func managedObjectModel(forResource resource: String) -> NSManagedObjectModel {
         let mainBundle = Bundle.main
         let subdirectory = "CoreDataMigration_Example.momd"
-        let omoURL = mainBundle.url(forResource: resource, withExtension: "omo", subdirectory: subdirectory) // optimized model file
+        
+        var omoURL: URL?
+        if #available(iOS 11, *) {
+            omoURL = mainBundle.url(forResource: resource, withExtension: "omo", subdirectory: subdirectory) // optimized model file
+        }
         let momURL = mainBundle.url(forResource: resource, withExtension: "mom", subdirectory: subdirectory)
         
         guard let url = omoURL ?? momURL else {


### PR DESCRIPTION
Fixed the inability of iOS 10 and earlier versions to load `NSManagedObjectModel` from optimized model file.

See [this](https://stackoverflow.com/questions/46876580/ios-9-10-coredata-failed-to-load-optimized-model-at-path) related stackoverflow question.